### PR TITLE
autoconverted syntax theme for atom

### DIFF
--- a/atom/.gitignore
+++ b/atom/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+npm-debug.log
+node_modules

--- a/atom/CHANGELOG.md
+++ b/atom/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0 - First Release
+* Every feature added
+* Every bug fixed

--- a/atom/README.md
+++ b/atom/README.md
@@ -1,0 +1,5 @@
+# fairyfloss-theme theme
+
+A short description of your theme.
+
+![A screenshot of your theme](https://f.cloud.github.com/assets/69169/2289498/4c3cb0ec-a009-11e3-8dbd-077ee11741e5.gif)

--- a/atom/index.less
+++ b/atom/index.less
@@ -1,0 +1,1 @@
+@import "./styles/base.less";

--- a/atom/package.json
+++ b/atom/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fairyfloss-theme",
+  "theme": "syntax",
+  "version": "1.0.0",
+  "author": "Amy Wibowo <sailorhg@gmail.com>",
+  "description": "Cute pastel theme created with ♥",
+  "keywords": [
+    "syntax",
+    "theme"
+  ],
+  "repository": "https://github.com/atom/fairyfloss-theme",
+  "license": "MIT",
+  "engines": {
+    "atom": ">=1.0.0 <2.0.0"
+  }
+}

--- a/atom/styles/base.less
+++ b/atom/styles/base.less
@@ -1,0 +1,143 @@
+@import "syntax-variables";
+
+atom-text-editor, :host {
+  background-color: @syntax-background-color;
+  color: @syntax-text-color;
+}
+
+atom-text-editor .gutter, :host .gutter {
+  background-color: @syntax-gutter-background-color;
+  color: @syntax-gutter-text-color;
+}
+
+atom-text-editor .gutter .line-number.cursor-line, :host .gutter .line-number.cursor-line {
+  background-color: @syntax-gutter-background-color-selected;
+  color: @syntax-gutter-text-color-selected;
+}
+
+atom-text-editor .gutter .line-number.cursor-line-no-selection, :host .gutter .line-number.cursor-line-no-selection {
+  color: @syntax-gutter-text-color-selected;
+}
+
+atom-text-editor .wrap-guide, :host .wrap-guide {
+  color: @syntax-wrap-guide-color;
+}
+
+atom-text-editor .indent-guide, :host .indent-guide {
+  color: @syntax-indent-guide-color;
+}
+
+atom-text-editor .invisible-character, :host .invisible-character {
+  color: @syntax-invisible-character-color;
+}
+
+atom-text-editor .search-results .marker .region, :host .search-results .marker .region {
+  background-color: transparent;
+  border: @syntax-result-marker-color;
+}
+
+atom-text-editor .search-results .marker.current-result .region, :host .search-results .marker.current-result .region {
+  border: @syntax-result-marker-color-selected;
+}
+
+atom-text-editor.is-focused .cursor, :host(.is-focused) .cursor {
+  border-color: @syntax-cursor-color;
+}
+
+atom-text-editor.is-focused .selection .region, :host(.is-focused) .selection .region {
+  background-color: @syntax-selection-color;
+}
+
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line, :host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
+  background-color: #3E3D32;
+}
+
+.comment {
+  color: #E6C000;
+}
+
+.string {
+  color: #FFEA00;
+}
+
+.constant.numeric {
+  color: #C5A3FF;
+}
+
+.constant.language {
+  color: #C5A3FF;
+}
+
+.constant.character, .constant.other {
+  color: #C5A3FF;
+}
+
+.variable {
+}
+
+.keyword {
+  color: #FFB8D1;
+}
+
+.storage {
+  color: #FFB8D1;
+}
+
+.storage.type {
+  font-style: italic;
+  color: #C2FFDF;
+}
+
+.entity.name.class {
+  text-decoration: underline;
+  color: #FFF352;
+}
+
+.entity.other.inherited-class {
+  font-style: italic;
+  text-decoration: underline;
+  color: #FFF352;
+}
+
+.entity.name.function {
+  color: #FFF352;
+}
+
+.variable.parameter {
+  font-style: italic;
+  color: #FF857F;
+}
+
+.entity.name.tag {
+  color: #FFB8D1;
+}
+
+.entity.other.attribute-name {
+  color: #FFF352;
+}
+
+.support.function {
+  color: #C2FFDF;
+}
+
+.support.constant {
+  color: #C2FFDF;
+}
+
+.support.type, .support.class {
+  font-style: italic;
+  color: #C2FFDF;
+}
+
+.support.other.variable {
+}
+
+.invalid {
+  color: #F8F8F0;
+  background-color: #F92672;
+}
+
+.invalid.deprecated {
+  color: #F8F8F0;
+  background-color: #AE81FF;
+}

--- a/atom/styles/syntax-variables.less
+++ b/atom/styles/syntax-variables.less
@@ -1,0 +1,30 @@
+// This defines all syntax variables that syntax themes must implement when they
+// include a syntax-variables.less file.
+
+// General colors
+@syntax-text-color: #F8F8F2;
+@syntax-cursor-color: #F8F8F0;
+@syntax-selection-color: #49483E;
+@syntax-background-color: #5A5475;
+
+// Guide colors
+@syntax-wrap-guide-color: #3B3A32;
+@syntax-indent-guide-color: #3B3A32;
+@syntax-invisible-character-color: #3B3A32;
+
+// For find and replace markers
+@syntax-result-marker-color: #3B3A32;
+@syntax-result-marker-color-selected: #F8F8F2;
+
+// Gutter colors
+@syntax-gutter-text-color: #F8F8F2;
+@syntax-gutter-text-color-selected: #F8F8F2;
+@syntax-gutter-background-color: #5A5475;
+@syntax-gutter-background-color-selected: #3E3D32;
+
+// For git diff info. i.e. in the gutter
+// These are static and were not extracted from your textmate theme
+@syntax-color-renamed: #96CBFE;
+@syntax-color-added: #A8FF60;
+@syntax-color-modified: #E9C062;
+@syntax-color-removed: #CC6666;


### PR DESCRIPTION
This is a straight-up conversion from the tmTheme.

It can be regenerated by doing this from the repo root:

apm init --theme ./atom --convert ./fairyfloss.tmTheme

More info on converted themes: http://flight-manual.atom.io/hacking-atom/sections/converting-from-textmate/

Also heads-up: You'll need to publish the theme to apm if you want it to be installable through the in-editor search, and I'm not terribly comfortable doing that _for_ you, but it's basically just an `apm publish major` away (I think you also need an account on the site tho) <3

Thanks for the theme! It's really cute and I'm gonna start using it now ^_^