### PR TITLE
fix color scheme for Atom

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -49,7 +49,7 @@ atom-text-editor.is-focused .selection .region, :host(.is-focused) .selection .r
 }
 
 atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line, :host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
-  background-color: #3E3D32;
+  background-color: @syntax-gutter-background-color-selected;
 }
 
 .comment {

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -4,23 +4,23 @@
 // General colors
 @syntax-text-color: #F8F8F2;
 @syntax-cursor-color: #F8F8F0;
-@syntax-selection-color: #49483E;
+@syntax-selection-color: #8077A8;
 @syntax-background-color: #5A5475;
 
 // Guide colors
-@syntax-wrap-guide-color: #3B3A32;
-@syntax-indent-guide-color: #3B3A32;
-@syntax-invisible-character-color: #3B3A32;
+@syntax-wrap-guide-color: #A8757B;
+@syntax-indent-guide-color: #A8757B;
+@syntax-invisible-character-color: #A8757B;
 
 // For find and replace markers
-@syntax-result-marker-color: #3B3A32;
-@syntax-result-marker-color-selected: #F8F8F2;
+@syntax-result-marker-color: #A8757B;
+@syntax-result-marker-color-selected: #716799;
 
 // Gutter colors
 @syntax-gutter-text-color: #F8F8F2;
 @syntax-gutter-text-color-selected: #F8F8F2;
 @syntax-gutter-background-color: #5A5475;
-@syntax-gutter-background-color-selected: #3E3D32;
+@syntax-gutter-background-color-selected: #716799;
 
 // For git diff info. i.e. in the gutter
 // These are static and were not extracted from your textmate theme


### PR DESCRIPTION
This should bring Atom closer to the version that Sublime Text users are enjoying.
