### PR TITLE
Add bracket highlight for atom, esp on the same line

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -52,6 +52,11 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   background-color: #3E3D32;
 }
 
+atom-text-editor.is-focused .bracket-matcher, :host(.is-focused) .bracket-matcher {
+  background-color: fade(@syntax-color-modified, 75%);
+  z-index: 1;
+}
+
 .comment {
   color: #E6C000;
 }


### PR DESCRIPTION
Hi!

I was having trouble seeing matching brackets, especially on the same line, so I thought I'd try to highlight them. I just picked a high-visibility color in the theme and am happy to change that choice, but the hard part here (for me) was figuring out the way atom does its layering in these cases. It puts the highlight below the current cursor line, so I popped it up with the z-index, but you can't see the underlying character without setting an alpha.

Current:
![before](https://cloud.githubusercontent.com/assets/1090771/15557212/ab56c5f2-2286-11e6-9367-0b07a80647e8.png)

With this change:
![after with match](https://cloud.githubusercontent.com/assets/1090771/15557213/adb1bbd6-2286-11e6-9e25-08053efbe038.png)

Even if this doesn't go in, I'd love to see some bracket matching in the theme. 😄 

Thanks!
