### PR TITLE
add markdown-specific styles for Atom

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -141,3 +141,31 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
   color: #F8F8F0;
   background-color: #AE81FF;
 }
+.syntax--heading{
+  color: #C5A3FF;
+}
+.syntax--heading-1{
+  font-weight:600;
+}
+.syntax--heading-2{
+  font-weight:500;
+}
+.sintax--heading-3{
+  font-weight:lighter
+}
+.syntax--bold{
+  font-weight:bold;
+}
+.syntax--list{
+  color: #C2FFDF
+}
+.syntax--raw{
+  background-color:#5a595f;
+}
+.syntax--link{
+  text-decoration: underline;
+  color: #FFB8D1;
+}
+.syntax--italic{
+  font-style: italic;
+}


### PR DESCRIPTION
![screen shot 2017-10-31 at 11 04 12 am](https://user-images.githubusercontent.com/585019/32241071-687e7638-be2c-11e7-95d3-414d3f445827.png)

# what
adds styling for markdown in Atom

# how
Atom already adds classes to markdown dynamically, so adding some .css for those classes is all that's necessary to add colors to .md documents

# concerns
* All headings have the same level and font-weight differentiates the first three levels. There's no great way (that I could think of) to continue this sequence down to h7, so h4 and lower all just a normal font weight. Also at least operator mono the bold weight is kind of ugly  ¯\_(ツ)_/¯

* a new background-color is added for code snippets, which hopefully will allow for syntax highlighting when Atom improves markdown support. I checked this new background with our existing font colors and it still passes the [accessible colors](http://accessible-colors.com/) test

# acknowledgements
[Ariel](https://github.com/arielspear) helped me figure this out
