### PR TITLE
Updated Atom syntax

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -1,143 +1,137 @@
 @import "syntax-variables";
 
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 }
 
-atom-text-editor .gutter, :host .gutter {
+atom-text-editor .gutter {
   background-color: @syntax-gutter-background-color;
   color: @syntax-gutter-text-color;
 }
 
-atom-text-editor .gutter .line-number.cursor-line, :host .gutter .line-number.cursor-line {
+atom-text-editor .gutter .line-number.cursor-line {
   background-color: @syntax-gutter-background-color-selected;
   color: @syntax-gutter-text-color-selected;
 }
 
-atom-text-editor .gutter .line-number.cursor-line-no-selection, :host .gutter .line-number.cursor-line-no-selection {
+atom-text-editor .gutter .line-number.cursor-line-no-selection {
   color: @syntax-gutter-text-color-selected;
 }
 
-atom-text-editor .wrap-guide, :host .wrap-guide {
+atom-text-editor .wrap-guide {
   color: @syntax-wrap-guide-color;
 }
 
-atom-text-editor .indent-guide, :host .indent-guide {
+atom-text-editor .indent-guide {
   color: @syntax-indent-guide-color;
 }
 
-atom-text-editor .invisible-character, :host .invisible-character {
+atom-text-editor .invisible-character {
   color: @syntax-invisible-character-color;
 }
 
-atom-text-editor .search-results .marker .region, :host .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region {
   background-color: transparent;
   border: @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region, :host .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region {
   border: @syntax-result-marker-color-selected;
 }
 
-atom-text-editor.is-focused .cursor, :host(.is-focused) .cursor {
+atom-text-editor.is-focused .cursor {
   border-color: @syntax-cursor-color;
 }
 
-atom-text-editor.is-focused .selection .region, :host(.is-focused) .selection .region {
+atom-text-editor.is-focused .selection .region {
   background-color: @syntax-selection-color;
 }
 
-atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line, :host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line {
   background-color: #3E3D32;
 }
 
-.comment {
+.syntax--comment {
   color: #E6C000;
 }
 
-.string {
+.syntax--string {
   color: #FFEA00;
 }
 
-.constant.numeric {
+.syntax--constant.syntax--numeric {
   color: #C5A3FF;
 }
 
-.constant.language {
+.syntax--constant.syntax--language {
   color: #C5A3FF;
 }
 
-.constant.character, .constant.other {
+.syntax--constant.syntax--character, .syntax--constant.syntax--other {
   color: #C5A3FF;
 }
 
-.variable {
-}
-
-.keyword {
+.syntax--keyword {
   color: #FFB8D1;
 }
 
-.storage {
+.syntax--storage {
   color: #FFB8D1;
 }
 
-.storage.type {
+.syntax--storage.syntax--type {
   font-style: italic;
   color: #C2FFDF;
 }
 
-.entity.name.class {
+.syntax--entity.syntax--name.syntax--class {
   text-decoration: underline;
   color: #FFF352;
 }
 
-.entity.other.inherited-class {
+.syntax--entity.syntax--other.syntax--inherited-class {
   font-style: italic;
   text-decoration: underline;
   color: #FFF352;
 }
 
-.entity.name.function {
+.syntax--entity.syntax--name.syntax--function {
   color: #FFF352;
 }
 
-.variable.parameter {
+.syntax--variable.syntax--parameter {
   font-style: italic;
   color: #FF857F;
 }
 
-.entity.name.tag {
+.syntax--entity.syntax--name.syntax--tag {
   color: #FFB8D1;
 }
 
-.entity.other.attribute-name {
+.syntax--entity.syntax--other.syntax--attribute-name {
   color: #FFF352;
 }
 
-.support.function {
+.syntax--support.syntax--function {
   color: #C2FFDF;
 }
 
-.support.constant {
+.syntax--support.syntax--constant {
   color: #C2FFDF;
 }
 
-.support.type, .support.class {
+.syntax--support.syntax--type, .syntax--support.syntax--class {
   font-style: italic;
   color: #C2FFDF;
 }
 
-.support.other.variable {
-}
-
-.invalid {
+.syntax--invalid {
   color: #F8F8F0;
   background-color: #F92672;
 }
 
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
   color: #F8F8F0;
   background-color: #AE81FF;
 }


### PR DESCRIPTION
I was getting a warning in atom for deprecated syntax (pasted below):

Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

* atom-text-editor, :host => atom-text-editor,atom-text-editor
* atom-text-editor .gutter, :host .gutter => atom-text-editor .gutter,atom-text-editor .gutter
* atom-text-editor .gutter .line-number.cursor-line, :host .gutter .line-number.cursor-line => atom-text-editor .gutter .line-number.cursor-line,atom-text-editor .gutter .line-number.cursor-line
* atom-text-editor .gutter .line-number.cursor-line-no-selection, :host .gutter .line-number.cursor-line-no-selection => atom-text-editor .gutter .line-number.cursor-line-no-selection,atom-text-editor .gutter .line-number.cursor-line-no-selection
* atom-text-editor .wrap-guide, :host .wrap-guide => atom-text-editor .wrap-guide,atom-text-editor .wrap-guide
* atom-text-editor .indent-guide, :host .indent-guide => atom-text-editor .indent-guide,atom-text-editor .indent-guide
* atom-text-editor .invisible-character, :host .invisible-character => atom-text-editor .invisible-character,atom-text-editor .invisible-character
* atom-text-editor .search-results .marker .region, :host .search-results .marker .region => atom-text-editor .search-results .syntax--marker .region,atom-text-editor .search-results .syntax--marker .region
* atom-text-editor .search-results .marker.current-result .region, :host .search-results  .marker.current-result .region => atom-text-editor .search-results .syntax--marker.current-result .region,atom-text-editor .search-results .syntax--marker.current-result .region
* atom-text-editor.is-focused .cursor, :host(.is-focused) .cursor => atom-text-editor.is-focused .cursor,atom-text-editor .cursor
* atom-text-editor.is-focused .selection .region, :host(.is-focused) .selection .region => atom-text-editor.is-focused .selection .region,atom-text-editor .selection .region
* atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line, :host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line => atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line,atom-text-editor .line-number.cursor-line-no-selection,atom-text-editor .line.cursor-line
* .comment => .syntax--comment
* .string => .syntax--string
* .constant.numeric => .syntax--constant.syntax--numeric
* .constant.language => .syntax--constant.syntax--language
* .constant.character, .constant.other => .syntax--constant.syntax--character, .syntax--constant.syntax--other
* .keyword => .syntax--keyword
* .storage => .syntax--storage
* .storage.type => .syntax--storage.syntax--type
* .entity.name.class => .syntax--entity.syntax--name.syntax--class
* .entity.other.inherited-class => .syntax--entity.syntax--other.syntax--inherited-class
* .entity.name.function => .syntax--entity.syntax--name.syntax--function
* .variable.parameter => .syntax--variable.syntax--parameter
* .entity.name.tag => .syntax--entity.syntax--name.syntax--tag
* .entity.other.attribute-name => .syntax--entity.syntax--other.syntax--attribute-name
* .support.function => .syntax--support.syntax--function
* .support.constant => .syntax--support.syntax--constant
* .support.type, .support.class => .syntax--support.syntax--type, .syntax--support.syntax--class
* .invalid => .syntax--invalid
* .invalid.deprecated => .syntax--invalid.syntax--deprecated
Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.

I think I've made all the specified updates.